### PR TITLE
feat(sower): limit resources per configuration

### DIFF
--- a/handlers/config.go
+++ b/handlers/config.go
@@ -7,10 +7,12 @@ import (
 
 // Container Struct to hold the configuration for Job Container
 type Container struct {
-	Name       string   `json:"name"`
-	Image      string   `json:"image"`
-	PullPolicy string   `json:"pull_policy"`
-	Env        []string `json:"env"`
+	Name        string   `json:"name"`
+	Image       string   `json:"image"`
+	PullPolicy  string   `json:"pull_policy"`
+	Env         []string `json:"env"`
+	CPULimit    string   `json:"cpu_limit"`
+	MemoryLimit string   `json:"memory_limit"`
 }
 
 // SowerConfig Struct to hold all the configuration

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -11,8 +11,8 @@ type Container struct {
 	Image       string   `json:"image"`
 	PullPolicy  string   `json:"pull_policy"`
 	Env         []string `json:"env"`
-	CPULimit    string   `json:"cpu_limit"`
-	MemoryLimit string   `json:"memory_limit"`
+	CPULimit    string   `json:"cpu-limit"`
+	MemoryLimit string   `json:"memory-limit"`
 }
 
 // SowerConfig Struct to hold all the configuration

--- a/handlers/jobs.go
+++ b/handlers/jobs.go
@@ -11,6 +11,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	batchtypev1 "k8s.io/client-go/kubernetes/typed/batch/v1"
@@ -183,6 +184,16 @@ func createK8sJob(inputData string, accessToken string, pelicanCreds PelicanCred
 								Privileged: &falseVal,
 							},
 							ImagePullPolicy: pullPolicy,
+							Resources: k8sv1.ResourceRequirements{
+								Limits: k8sv1.ResourceList{
+									k8sv1.ResourceCPU:    resource.MustParse(conf.Container.CPULimit),
+									k8sv1.ResourceMemory: resource.MustParse(conf.Container.MemoryLimit),
+								},
+								Requests: k8sv1.ResourceList{
+									k8sv1.ResourceCPU:    resource.MustParse(conf.Container.CPULimit),
+									k8sv1.ResourceMemory: resource.MustParse(conf.Container.MemoryLimit),
+								},
+							},
 							Env: []k8sv1.EnvVar{
 								{
 									Name:  "GEN3_HOSTNAME",


### PR DESCRIPTION
**Breaking change:**
* `sower` now support setting resource limit for CPU & memory in the manifest.