### PR TITLE
updating the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch as build-deps
+FROM quay.io/cdis/golang:1.12-stretch as build-deps
 
 WORKDIR $GOPATH/src/github.com/uc-cdis/sower/
 


### PR DESCRIPTION
Updating the DockerFile image for Quay build rate limit issue

Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit

