### PR TITLE
chore(empty_config_log): add error description for a missing action e…

### DIFF
--- a/handlers/jobs.go
+++ b/handlers/jobs.go
@@ -126,7 +126,10 @@ func createK8sJob(currentAction string, inputData string, accessFormat string, a
 	var getCurrentAction = func(s SowerConfig) bool { return s.Action == currentAction }
 	var actions = filter(availableActions, getCurrentAction)
 
-	if len(actions) != 1 {
+	if len(actions) == 0 {
+		fmt.Println("ERROR: %V is not in sower config", currentAction)
+		return nil, nil
+	} else if len(actions) != 1 {
 		fmt.Println("ERROR: There is a duplicate in sower config")
 		return nil, nil
 	}


### PR DESCRIPTION
### Improvements

- When a job is dispatched but does not exist in `sower_config.json`, indicate an empty config instead of a duplicate in logs