### PR TITLE
fix: update certificates due to LetsEncrypt root certificate expiration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY go.mod .
 COPY go.sum .
 
 ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
* Updating certificates to fix installing Go packages

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
