### PR TITLE
Sanitize Auth0 user_id for Kubernetes labels (export/import job fix)

### DIFF
--- a/.github/workflows/golang-ci-workflow.yaml
+++ b/.github/workflows/golang-ci-workflow.yaml
@@ -6,13 +6,14 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: "1.23"
+      GO_VERSION: "1.26"
       COVERAGE_PROFILE_OUTPUT_LOCATION: "./profile.cov"
     steps:
       - name: Checkout code / lint code / install dependencies for goveralls / run tests
         uses: uc-cdis/.github/.github/actions/golang-ci@master
         with:
           COVERAGE_PROFILE_OUTPUT_LOCATION: ${{ env.COVERAGE_PROFILE_OUTPUT_LOCATION }}
+          GO_VERSION: ${{ env.GO_VERSION }}
       - name: Send coverage to coveralls using goveralls
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GOARCH=amd64
 
 # Use Go toolchains (Go 1.21+ feature) to build with a newer Go toolchain
 # Pick the Go 1.2x.x that is needed for the build.
-ENV GOTOOLCHAIN=go1.26.0
+ENV GOTOOLCHAIN=go1.26.1
 
 WORKDIR $GOPATH/src/github.com/uc-cdis/sower/
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/uc-cdis/sower
 
-go 1.23.0
+go 1.26
 
-toolchain go1.23.5
+toolchain go1.26.0
 
 require (
 	github.com/MicahParks/keyfunc v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/uc-cdis/sower
 
 go 1.26
 
-toolchain go1.26.0
+toolchain go1.26.1
 
 require (
 	github.com/MicahParks/keyfunc v1.9.0

--- a/handlers/jobs.go
+++ b/handlers/jobs.go
@@ -71,7 +71,7 @@ func getJobByID(jobid string, username string) (*batchv1.Job, error) {
 	if username == "" { // this is needed for StartMonitoringProcess function only
 		labelSelector = fmt.Sprintf("app=%s", "sowerjob")
 	} else {
-		labelSelector = fmt.Sprintf("app=%s,username=%s", "sowerjob", sanitizeLabelValue(username))
+		labelSelector = fmt.Sprintf("app=%s,username=%s", "sowerjob", username)
 	}
 
 	jobs, err := jc.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
@@ -100,7 +100,7 @@ func getJobStatusByID(jobid string, username string) (*JobInfo, error) {
 func listJobs(jc batchtypev1.JobInterface, username string) []JobInfo {
 	jobs := []JobInfo{}
 
-	labelSelector := fmt.Sprintf("app=%s,username=%s", "sowerjob", sanitizeLabelValue(username))
+	labelSelector := fmt.Sprintf("app=%s,username=%s", "sowerjob", username)
 
 	jobsList, err := jc.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
@@ -160,8 +160,7 @@ func createK8sJob(currentAction string, inputData string, accessFormat string, a
 	var ttl int32 = 3600 // Keep job pods for 1 hour by default
 	labels := make(map[string]string)
 	labels["app"] = "sowerjob"
-	safeUsername := sanitizeLabelValue(username)
-	labels["username"] = safeUsername
+	labels["username"] = username
 	if len(conf.Container.Labels) != 0 {
 		for k, v := range conf.Container.Labels {
 			labels[k] = v
@@ -170,8 +169,6 @@ func createK8sJob(currentAction string, inputData string, accessFormat string, a
 
 	annotations := make(map[string]string)
 	annotations["gen3username"] = userName
-	// Preserve the original (unsanitized) principal for audit/debug:
-    annotations["gen3.original-username"] = username
 
 	var privileged = false
 

--- a/handlers/jobs.go
+++ b/handlers/jobs.go
@@ -71,7 +71,7 @@ func getJobByID(jobid string, username string) (*batchv1.Job, error) {
 	if username == "" { // this is needed for StartMonitoringProcess function only
 		labelSelector = fmt.Sprintf("app=%s", "sowerjob")
 	} else {
-		labelSelector = fmt.Sprintf("app=%s,username=%s", "sowerjob", username)
+		labelSelector = fmt.Sprintf("app=%s,username=%s", "sowerjob", sanitizeLabelValue(username))
 	}
 
 	jobs, err := jc.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
@@ -100,7 +100,7 @@ func getJobStatusByID(jobid string, username string) (*JobInfo, error) {
 func listJobs(jc batchtypev1.JobInterface, username string) []JobInfo {
 	jobs := []JobInfo{}
 
-	labelSelector := fmt.Sprintf("app=%s,username=%s", "sowerjob", username)
+	labelSelector := fmt.Sprintf("app=%s,username=%s", "sowerjob", sanitizeLabelValue(username))
 
 	jobsList, err := jc.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
@@ -160,7 +160,8 @@ func createK8sJob(currentAction string, inputData string, accessFormat string, a
 	var ttl int32 = 3600 // Keep job pods for 1 hour by default
 	labels := make(map[string]string)
 	labels["app"] = "sowerjob"
-	labels["username"] = username
+	safeUsername := sanitizeLabelValue(username)
+	labels["username"] = safeUsername
 	if len(conf.Container.Labels) != 0 {
 		for k, v := range conf.Container.Labels {
 			labels[k] = v
@@ -169,6 +170,8 @@ func createK8sJob(currentAction string, inputData string, accessFormat string, a
 
 	annotations := make(map[string]string)
 	annotations["gen3username"] = userName
+	// Preserve the original (unsanitized) principal for audit/debug:
+    annotations["gen3.original-username"] = username
 
 	var privileged = false
 

--- a/handlers/sower.go
+++ b/handlers/sower.go
@@ -94,28 +94,35 @@ func dispatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func status(w http.ResponseWriter, r *http.Request) {
-	email := ""
+    UID := r.URL.Query().Get("UID")
+    if UID != "" {
+        username := ""
+        if bt := getBearerToken(r); bt != nil && *bt != "" {
+            if p, err := getPrincipalFromToken(*bt); err == nil {
+                username = p.LabelSafe
+            }
+        }
 
-	UID := r.URL.Query().Get("UID")
-	if UID != "" {
-		result, errUID := getJobStatusByID(UID, email)
-		if errUID != nil {
-			http.Error(w, errUID.Error(), 500)
-			return
-		}
+        result, errUID := getJobStatusByID(UID, sanitizeLabelValue(username))
+        if errUID != nil {
+            http.Error(w, errUID.Error(), 500)
+            return
+        }
 
-		out, err := json.Marshal(result)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
+        out, err := json.Marshal(result)
+        if err != nil {
+            http.Error(w, err.Error(), 500)
+            return
+        }
 
-		fmt.Fprint(w, string(out))
-	} else {
-		http.Error(w, "Missing UID argument", 300)
-		return
-	}
+        fmt.Fprint(w, string(out))
+    } else {
+        http.Error(w, "Missing UID argument", 400)
+        return
+    }
 }
+
+
 
 func output(w http.ResponseWriter, r *http.Request) {
 	accessToken := getBearerToken(r)
@@ -125,14 +132,14 @@ func output(w http.ResponseWriter, r *http.Request) {
 		accessTokenVal = *accessToken
 	}
 
-	email, err := getEmailFromToken(accessTokenVal)
+	principal, err := getPrincipalFromToken(accessTokenVal)
 	if err != nil {
 		panic(err.Error())
 	}
 
 	UID := r.URL.Query().Get("UID")
 	if UID != "" {
-		result, errUID := getJobLogs(UID, email)
+		result, errUID := getJobLogs(UID, principal.LabelSafe)
 		if errUID != nil {
 			http.Error(w, errUID.Error(), 500)
 			return
@@ -179,12 +186,12 @@ func list(w http.ResponseWriter, r *http.Request) {
 		accessTokenVal = *accessToken
 	}
 
-	email, err := getEmailFromToken(accessTokenVal)
+	principal, err := getPrincipalFromToken(accessTokenVal)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	result := listJobs(getJobClient(), email)
+	result := listJobs(getJobClient(), principal.LabelSafe)
 
 	out, err := json.Marshal(result)
 	if err != nil {
@@ -207,20 +214,20 @@ func getBearerToken(r *http.Request) *string {
 	return nil
 }
 
-func getEmailFromToken(accessTokenVal string) (string, error) {
+func getPrincipalFromToken(accessTokenVal string) (Principal, error) {
 	jwksURL := "http://fence-service/.well-known/jwks"
 
 	// create the JWKS from the resource at the given URL
 	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
 	if err != nil {
 		log.Debugf("Failed to create JWKS from resource at the given URL.\nError: %s", err.Error())
-		return "", err
+		return Principal{}, err
 	}
 
 	token, err := jwt.Parse(accessTokenVal, jwks.Keyfunc)
 	if err != nil {
 		log.Debugf("Failed to parse the JWT.\nError: %s", err.Error())
-		return "", err
+		return Principal{}, err
 	}
 
 	// Verify if sub field exists, to identify if it is a user token or a client token
@@ -233,9 +240,9 @@ func getEmailFromToken(accessTokenVal string) (string, error) {
 			// User token
 			context := claims["context"].(map[string]interface{})
 			user := context["user"].(map[string]interface{})
-			username := user["name"].(string)
             // This field was previously called "email" or "username"; it’s really a principal ID.
             raw := user["name"].(string) // often email-ish or provider-prefixed ID
+			raw = strings.ReplaceAll(raw, "@", "_")
             return Principal{Raw: raw, LabelSafe: sanitizeLabelValue(raw)}, nil
 		} else if claims["azp"] != nil {
 			// Client token
@@ -243,5 +250,5 @@ func getEmailFromToken(accessTokenVal string) (string, error) {
             return Principal{Raw: raw, LabelSafe: sanitizeLabelValue(raw)}, nil
 		}
 	}
-	return "", nil
+	return Principal{}, nil
 }

--- a/handlers/sower.go
+++ b/handlers/sower.go
@@ -41,7 +41,11 @@ func dispatch(w http.ResponseWriter, r *http.Request) {
 	accessToken := getBearerToken(r)
 
 	inputDataStr, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			log.WithError(err).Error("failed to close request body")
+		}
+	}()
 
 	if err != nil {
 		http.Error(w, err.Error(), 500)
@@ -55,7 +59,7 @@ func dispatch(w http.ResponseWriter, r *http.Request) {
 
 	var currentAction = inputRequest.Action
 
-	var accessFormat string = "presigned_url"
+	var accessFormat = "presigned_url"
 
 	if inputRequest.Format != "" {
 		accessFormat = inputRequest.Format
@@ -90,7 +94,9 @@ func dispatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprint(w, string(out))
+	if _, err := fmt.Fprint(w, string(out)); err != nil {
+		log.WithError(err).Error("failed to write response")
+	}
 }
 
 func status(w http.ResponseWriter, r *http.Request) {
@@ -115,11 +121,14 @@ func status(w http.ResponseWriter, r *http.Request) {
             return
         }
 
-        fmt.Fprint(w, string(out))
-    } else {
-        http.Error(w, "Missing UID argument", 400)
-        return
-    }
+		if _, err := fmt.Fprint(w, string(out)); err != nil {
+			log.WithError(err).Error("failed to write response")
+		}
+
+	} else {
+		http.Error(w, "Missing UID argument", http.StatusMultipleChoices)
+		return
+	}
 }
 
 
@@ -158,7 +167,7 @@ func output(w http.ResponseWriter, r *http.Request) {
 		logLines := strings.FieldsFunc(result.Output, newLineSep)
 		for _, logLine := range logLines {
 			if strings.Contains(logLine, "[out] ") {
-				resLine = strings.Replace(logLine, "[out] ", "", -1)
+				resLine = strings.ReplaceAll(logLine, "[out] ", "")
 			}
 		}
 
@@ -171,9 +180,12 @@ func output(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fmt.Fprint(w, string(res))
+		if _, err := fmt.Fprint(w, string(res)); err != nil {
+			log.WithError(err).Error("failed to write response")
+		}
+
 	} else {
-		http.Error(w, "Missing UID argument", 300)
+		http.Error(w, "Missing UID argument", http.StatusMultipleChoices)
 		return
 	}
 }
@@ -199,7 +211,9 @@ func list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprint(w, string(out))
+	if _, err := fmt.Fprint(w, string(out)); err != nil {
+		log.WithError(err).Error("failed to write response")
+	}
 }
 
 func getBearerToken(r *http.Request) *string {

--- a/handlers/system.go
+++ b/handlers/system.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/apex/log"
 	"github.com/uc-cdis/sower/handlers/version"
 )
 
@@ -19,7 +20,9 @@ func RegisterSystem() {
 }
 
 func systemStatus(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Healthy")
+	if _, err := fmt.Fprint(w, "Healthy"); err != nil {
+		log.WithError(err).Error("failed to write systemStatus response")
+	}
 }
 
 func systemVersion(w http.ResponseWriter, r *http.Request) {
@@ -30,5 +33,7 @@ func systemVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprint(w, string(out))
+	if _, err := fmt.Fprint(w, string(out)); err != nil {
+		log.WithError(err).Error("failed to write systemVersion response")
+	}
 }

--- a/handlers/util.go
+++ b/handlers/util.go
@@ -1,5 +1,11 @@
 package handlers
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+)
+
 func filter(scs []SowerConfig, test func(SowerConfig) bool) (ret []SowerConfig) {
 	for _, s := range scs {
 		if test(s) {
@@ -7,4 +13,32 @@ func filter(scs []SowerConfig, test func(SowerConfig) bool) (ret []SowerConfig) 
 		}
 	}
 	return
+}
+
+var (
+	// valid: alphanum, '-', '_', '.', must start/end alnum, <= 63 chars
+	labelAllowed = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+	trimEnds     = regexp.MustCompile(`^[^A-Za-z0-9]+|[^A-Za-z0-9]+$`)
+	collapseDash = regexp.MustCompile(`[-._]{2,}`)
+)
+
+func sanitizeLabelValue(raw string) string {
+	if raw == "" {
+		return "id-" + shortHash("empty")
+	}
+	s := labelAllowed.ReplaceAllString(raw, "-")
+	s = collapseDash.ReplaceAllString(s, "-")
+	s = trimEnds.ReplaceAllString(s, "")
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	if s == "" {
+		return "id-" + shortHash(raw)
+	}
+	return s
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])[:16]
 }


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->


### Bug Fixes
Fixes job creation failures when Auth0 user IDs (containing |) are used as label values.

#### Root Cause

username was injected directly into metadata.labels, violating Kubernetes label rules.

#### Fix

Added sanitizeLabelValue() in handlers/sanitize.go

Applied sanitization when creating job labels and selectors

Preserved original username in metadata.annotations["gen3.original-username"]

Updated Dockerfile to build correctly in forks and CI (no .git dependency)

#### Affected actions

Export (e.g. Pelican/PFB)

Import jobs (same label pipeline)

#### Testing

Verified job creation and status endpoints with Auth0 user IDs.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
